### PR TITLE
feat: add hatchet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ fastapi = "^0.109.2"
 uvicorn = "^0.27.0.post1"
 tqdm = "^4.66.1"
 python-multipart = "^0.0.9"
+hatchet-sdk = "^0.9.4"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"

--- a/sciphi_r2r/examples/basic/app.py
+++ b/sciphi_r2r/examples/basic/app.py
@@ -1,6 +1,8 @@
 import logging
+import threading
 
 import dotenv
+from sciphi_r2r.examples.basic.worker import get_worker
 import uvicorn
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 
@@ -11,6 +13,7 @@ from sciphi_r2r.llms import OpenAIConfig, OpenAILLM
 from sciphi_r2r.main import create_app, load_config
 from sciphi_r2r.pipelines import BasicEmbeddingPipeline, BasicRAGPipeline
 from sciphi_r2r.vector_dbs import PGVectorDB
+from hatchet_sdk import Hatchet
 
 if __name__ == "__main__":
     dotenv.load_dotenv()
@@ -77,8 +80,20 @@ if __name__ == "__main__":
         text_splitter=text_splitter,
     )
 
+    hatchet = Hatchet(debug=True)
+
+    worker = get_worker(
+        hatchet=hatchet,
+        embedding_pipeline=embd_pipeline,
+    )
+
+    # in this case, we start the worker in a separate thread
+    thread = threading.Thread(target=worker.start)
+    thread.start()
+
     app = create_app(
         embedding_pipeline=embd_pipeline,
         rag_pipeline=cmpl_pipeline,
+        hatchet=hatchet,
     )
     uvicorn.run(app, host=api_config["host"], port=api_config["port"])

--- a/sciphi_r2r/examples/basic/worker.py
+++ b/sciphi_r2r/examples/basic/worker.py
@@ -1,0 +1,36 @@
+
+from sciphi_r2r.main.app import TextEntryModel
+from sciphi_r2r.pipelines import BasicEmbeddingPipeline
+from hatchet_sdk import Hatchet, Context
+from dotenv import load_dotenv
+
+load_dotenv()
+
+def get_worker(
+        hatchet: Hatchet,
+        embedding_pipeline: BasicEmbeddingPipeline,
+) -> Hatchet:
+    @hatchet.workflow(on_events=["embedding"],name="embedding-workflow")
+    class EmbeddingWorkflow:
+        def __init__(self, embd_pipeline):
+            self.embd_pipeline = embd_pipeline
+
+        @hatchet.step()
+        def run(self, context: Context):
+            input = context.workflow_input()
+
+            text_entry = TextEntryModel(
+                id=input.get("id"), text=input.get("text"), metadata=input.get("metadata")
+            )
+
+            result = self.embd_pipeline.run(
+                text_entry
+            )
+
+            return result
+    
+    workflow = EmbeddingWorkflow(embedding_pipeline)
+    worker = hatchet.worker('sciphi-worker', max_threads=4)
+    worker.register_workflow(workflow)
+
+    return worker

--- a/sciphi_r2r/main/app.py
+++ b/sciphi_r2r/main/app.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel
 from sciphi_r2r.core import EmbeddingPipeline, RAGPipeline
 from sciphi_r2r.main.utils import configure_logging
 
+from hatchet_sdk import Hatchet
+
 logger = logging.getLogger("sciphi_r2r")
 
 # Current directory where this script is located
@@ -37,6 +39,7 @@ class RAGQueryModel(BaseModel):
 def create_app(
     embedding_pipeline: EmbeddingPipeline,
     rag_pipeline: RAGPipeline,
+    hatchet: Hatchet,
     upload_path: Optional[Path] = None,
 ):
     app = FastAPI()
@@ -83,7 +86,11 @@ def create_app(
     @app.post("/upsert_text_entry/")
     def upsert_text_entry(text_entry: TextEntryModel):
         try:
-            embedding_pipeline.run(text_entry)
+            # TODO: case on whether Hatchet exists or not
+            hatchet.client.event.push("embedding", {"id": text_entry.id, "text": text_entry.text, "metadata": text_entry.metadata})
+
+            # embedding_pipeline.run(text_entry)
+
             return {"message": "Entry upserted successfully."}
         except Exception as e:
             logger.error(


### PR DESCRIPTION
This PR illustrates adding Hatchet to r2r. 

To get started and generate a local token, see the docs here: https://docs.hatchet.run/home/python-sdk/setup#usage. 

**Before running this in production**, note that the Hatchet worker should ideally be running in its own process. While it will work to spawn the worker in its own thread, it will lead to unpredictable behavior, as Hatchet also manages threading internally. 

Next steps:
- [ ] Ensure that the API handlers can properly case on whether Hatchet is enabled or not
- [ ] Set a retry count on the steps
- [ ] Set a timeout on the steps 