### PR TITLE
fix: set `max_threads` to a higher count

### DIFF
--- a/sciphi_r2r/main/worker.py
+++ b/sciphi_r2r/main/worker.py
@@ -46,7 +46,7 @@ def get_worker(
             return result
 
     embedding_workflow = EmbeddingWorkflow(embedding_pipeline)
-    worker = hatchet.worker("sciphi-worker", max_threads=4)
+    worker = hatchet.worker("sciphi-worker", max_threads=200)
 
     worker.register_workflow(embedding_workflow)
 


### PR DESCRIPTION
Updates `max_threads` from 4 to 200 to relieve bottleneck. 